### PR TITLE
Restore the initial GPIO settings in app_config.h

### DIFF
--- a/source/ble2uart/source/app.c
+++ b/source/ble2uart/source/app.c
@@ -1,7 +1,7 @@
+#include "app_config.h"
 #include "tl_common.h"
 //#include "drivers.h"
 #include "stack/ble/ble.h"
-#include "app_config.h"
 //#include "vendor/common/blt_common.h"
 //#include "cmd_parser.h"
 #include "ble.h"

--- a/source/ble2uart/source/app_buffer.h
+++ b/source/ble2uart/source/app_buffer.h
@@ -46,8 +46,8 @@
 #ifndef APP_BUFFER_H_
 #define APP_BUFFER_H_
 
-#include "tl_common.h"
 #include "app_config.h"
+#include "tl_common.h"
 
 
 #define SET_MAX_BUF		23

--- a/source/ble2uart/source/app_config.h
+++ b/source/ble2uart/source/app_config.h
@@ -24,13 +24,66 @@
 
 // TB-03F-KIT           TLSR8253F512 PIN and description of the application function
 #define	KEY_USER		GPIO_PA7  // SWS (UART_DTR)
+
+#define	GPIO_KEY1				GPIO_PA7
+#define PA7_FUNC					AS_GPIO
+#define PA7_OUTPUT_ENABLE			0
+#define PA7_INPUT_ENABLE			1
+#define	PULL_WAKEUP_SRC_PA7			PM_PIN_PULLUP_10K
+
 #define GPIO_LED_B		GPIO_PC2  // RGB Blue LED1, C2: Coded PHY advertisement received
+#define PC2_DATA_OUT		0
+#define PC2_OUTPUT_ENABLE	1
+#define PC2_INPUT_ENABLE	1
+#define PC2_FUNC			AS_GPIO
+#define PWM_LED_B		PWM0_ID
+
 #define GPIO_LED_R		GPIO_PC3  // RGB Red LED1, C3 (PWM1): FIFO overflow errors, when the UART troughtput is not enough to process all received BLE advertisements
+#define PC3_DATA_OUT		0
+#define PC3_OUTPUT_ENABLE	1
+#define PC3_INPUT_ENABLE	1
+#define PC3_FUNC			AS_GPIO
+#define PWM_LED_R		PWM1_ID
+
 #define GPIO_LED_G		GPIO_PC4  // RGB Green LED1, C4 (PWM2): PHY 1M advertisement received
+#define PC4_DATA_OUT		0
+#define PC4_OUTPUT_ENABLE	1
+#define PC4_INPUT_ENABLE	1
+#define PC4_FUNC			AS_GPIO
+#define PWM_LED_G		PWM2_ID
+
 #define GPIO_LED_E		GPIO_PB4  // Lateral small Yellow LED3, B4: Advertisement succesfully sent to the UART FIFO
+#define PB4_DATA_OUT		0
+#define PB4_OUTPUT_ENABLE	1
+#define PB4_INPUT_ENABLE	1
+#define PB4_FUNC			AS_GPIO
+
 #define GPIO_LED_W		GPIO_PB5  // Lateral White LED2, B5: Host command received from the UART
+#define PB5_DATA_OUT		0
+#define PB5_OUTPUT_ENABLE	1
+#define PB5_INPUT_ENABLE	1
+#define PB5_FUNC			AS_GPIO
+
 #define GPIO_TX			GPIO_PB1  // UART_TX_PB1, TXD
+
 #define GPIO_RX			GPIO_PA0  // UART_RX_PA0, RXD
+#define PA0_OUTPUT_ENABLE	0
+#define PULL_WAKEUP_SRC_PA0 PM_PIN_PULLUP_1M
+#define PA0_FUNC		AS_GPIO
+
+#if UART_PRINT_DEBUG_ENABLE
+#define PRINT_BAUD_RATE 1500000 // real 1000000
+#define DEBUG_INFO_TX_PIN	GPIO_PB1
+#define PB1_DATA_OUT		1
+#define PB1_OUTPUT_ENABLE	1
+#define PULL_WAKEUP_SRC_PB1 PM_PIN_PULLUP_1M
+#define PB1_FUNC		AS_GPIO
+#endif // UART_PRINT_DEBUG_ENABLE
+
+#define PC2_DATA_OUT		0
+#define PC2_OUTPUT_ENABLE	1
+#define PC2_INPUT_ENABLE	1
+#define PC2_FUNC			AS_GPIO
 
 /* Power 3.3V, RX RF + TX ADV 1 sec, max:
  * 48MHz 7.3 mA

--- a/source/ble2uart/source/ble.c
+++ b/source/ble2uart/source/ble.c
@@ -1,7 +1,7 @@
+#include "app_config.h"
 #include "tl_common.h"
 #include "app_buffer.h"
 #include "drivers.h"
-#include "app_config.h"
 #include "drivers/8258/gpio_8258.h"
 #include "ble.h"
 #include "app.h"

--- a/source/ble2uart/source/drv_uart.c
+++ b/source/ble2uart/source/drv_uart.c
@@ -4,10 +4,10 @@
  *  Created on: 04.03.2024
  *      Author: pvvx
  */
+#include "app_config.h"
 #include "tl_common.h"
 #include "drivers/8258/register_8258.h"
 #include "drv_uart.h"
-#include "app_config.h"
 
 //--- UART DMA buffers ----------------------------
 

--- a/source/ble2uart/source/main.c
+++ b/source/ble2uart/source/main.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
+#include "app_config.h"
 #include "tl_common.h"
 #include "drivers.h"
 #include "stack/ble/ble.h"
 #include "app.h"
-#include "app_config.h"
 
 #if (MCU_CORE_TYPE == MCU_CORE_9518)
 	/* default flash is 1M
@@ -182,28 +182,8 @@ _attribute_ram_code_ int main (void) {    //must run in ramcode
 
 	clock_init(SYS_CLK_TYPE);
 
-	rf_drv_init(RF_MODE_BLE_1M);
-
 	_gpio_init(!deepRetWakeUp);  // analog resistance will keep available in deepSleep mode, so no need to initialize it again
-
-    // Initialize ports for the used LEDs
-    int leds[] = { GPIO_LED_B, GPIO_LED_R, GPIO_LED_G, GPIO_LED_E, GPIO_LED_W };
-    for (size_t i = 0; i < sizeof(leds)/sizeof(leds[0]); i++) {
-        gpio_set_func(leds[i], AS_GPIO);
-        gpio_set_output_en(leds[i], 1);
-        gpio_set_data_strength(leds[i], 1);
-    }
-
-    // Initialize UART RX port
-    gpio_set_func(GPIO_RX, AS_GPIO);
-    gpio_set_input_en(GPIO_RX, 1);
-    gpio_setup_up_down_resistor(GPIO_RX, PM_PIN_PULLUP_1M);
-
-    // Initialize UART TX port
-    gpio_set_func(GPIO_TX, AS_GPIO);
-    gpio_set_output_en(GPIO_TX, 1);
-    gpio_set_data_strength(GPIO_TX, 1);
-    gpio_setup_up_down_resistor(GPIO_TX, PM_PIN_PULLUP_1M);
+	rf_drv_init(RF_MODE_BLE_1M);
 
 	adc_power_on_sar_adc(0); // - 0.4 mA
 	lpc_power_down();

--- a/source/ble2uart/source/scanning.c
+++ b/source/ble2uart/source/scanning.c
@@ -4,10 +4,10 @@
  *  Created on: 20.11.2021
  *      Author: pvvx
  */
+#include "app_config.h"
 #include "tl_common.h"
 #include "ble.h"
 #include "stack/ble/ble.h"
-#include "app_config.h"
 //#include "app.h"
 #include "drv_uart.h"
 #include "crc.h"


### PR DESCRIPTION
This PR follows https://github.com/pvvx/TLSR825x_ADV_BLE2UART/issues/12#issue-2218721658

With the latest version of the SDK, in order to avoid that some includes pre-load the default "gpio_default_8258.h" (the following includes have it nested: "tl_common.h", "drivers.h", "stack/ble/ble.h"), we would need to have "app_config.h" before "tl_common.h".