### PR TITLE
Add app-printf (printf utilities for this app)

### DIFF
--- a/source/ble2uart/source/app_printf.h
+++ b/source/ble2uart/source/app_printf.h
@@ -6,4 +6,7 @@ int  u_printf(const char *fmt, ...);
 int  u_sprintf(char* s, const char *fmt, ...);
 void u_array_printf(unsigned char*data, unsigned int len);
 int print(char **out, const char *format, va_list args);
+int u_sprintf(char *out, const char *format, ...);  // see uprintf.mk
 void uart_printf(const char *format, ...);
+int raw_printf(const char *format, ...);
+int p_printf(const char *format, ...);

--- a/source/ble2uart/source/project.mk
+++ b/source/ble2uart/source/project.mk
@@ -14,7 +14,7 @@ $(OUT_PATH)/source/scanning.o \
 $(OUT_PATH)/source/ble.o \
 $(OUT_PATH)/source/drv_uart.o \
 $(OUT_PATH)/source/tinyFlash.o \
-$(OUT_PATH)/source/u_printf.o \
+$(OUT_PATH)/source/app_printf.o \
 $(OUT_PATH)/source/main.o
 
 # Each subdirectory must supply rules for building sources it contributes

--- a/source/ble2uart/source/scanning.c
+++ b/source/ble2uart/source/scanning.c
@@ -13,7 +13,7 @@
 #include "crc.h"
 #include "utils.h"
 #include "scanning.h"
-#include "u_printf.h"
+#include "app_printf.h"
 
 typedef struct {
 #if defined(GPIO_LED_R)


### PR DESCRIPTION
**Add app-printf (printf utilities for this app)**

A `uart_printf()` message is printed by *adv2uart.py* as a `Command.DEBUG_PRINT` warning and uses the FIFO.

The `p_printf()` function writes a `Command.DEBUG_PRINT` packet to the USB UART without using the FIFO.

The `raw_printf()` function writes raw data to the USB UART directly calling `uart_send()`, without using FIFO/headers/crc, and it is not compatible with *adv2uart.py*.

Other included functions are inefficient and usage is discouraged.